### PR TITLE
Make email address consistent with other lists

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@ Signalen development team is strongly committed to responsible reporting and dis
 
 ## Reporting security issues
 
-**Short version: please report security issues by emailing security@signalen.org.**
+**Short version: please report security issues by emailing signalen-security@lists.publiccode.net.**
 
-If you discover security issues in Signalen we request you to disclose these in a *responsible* way by e-mailing to security@signalen.org.
+If you discover security issues in Signalen we request you to disclose these in a *responsible* way by e-mailing to signalen-security@lists.publiccode.net.
 
 It is extremely useful if you have a reproducible test case and/or clear steps on how to reproduce the vulnerability.
 


### PR DESCRIPTION
## Description

Using:
  "signalen-security@lists.publiccode.net"
would match:
  "signalen-discuss@lists.publiccode.net"
And not require setting up a second email infrastructure yet.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Documentation has been updated if needed
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [ ] Check that the PR targets `master` (**(not applicable)**)
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?
(not applicable)
- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 90% (the higher the better)
- [ ] No iSort issues are present in the code
- [ ] No Flake8 issues are present in the code
